### PR TITLE
Specify exact version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests
-six
+requests==2.18.4
+six==1.11.0


### PR DESCRIPTION
As a general practice, it's recommended to specify the exact version of the package dependencies. This avoids unexpected issues when external dependencies are updated.