### PR TITLE
Filter remote solvers by the problem type client handles

### DIFF
--- a/dwave_micro_client.py
+++ b/dwave_micro_client.py
@@ -1512,7 +1512,7 @@ def load_configuration(key=None):
             data = {index: value for index, value in enumerate(data.split(','))}
 
             if label == key or data[0] == key or key is None:
-                return data[0], data[1], data.get(2, ''), data.get(3, '')
+                return data[0] or None, data[1] or None, data.get(2), data.get(3)
         except:
             pass  # Just ignore any malformed lines
             # TODO issue a warning

--- a/dwave_micro_client.py
+++ b/dwave_micro_client.py
@@ -334,8 +334,11 @@ class Connection:
 
                 response.raise_for_status()
 
-                data = json.loads(response.text)
-                self.solvers[data['id']] = Solver(self, data)
+                solver = Solver(self, data=response.json())
+                if solver.id != name:
+                    raise InvalidAPIResponseError(
+                        "Asked for solver named {!r}, got {!r}".format(name, solver.id))
+                self.solvers[name] = solver
 
             return self.solvers[name]
 

--- a/test/test_mock_solver_loading.py
+++ b/test/test_mock_solver_loading.py
@@ -7,7 +7,6 @@ import unittest
 import requests_mock
 
 import dwave_micro_client
-from dwave_micro_client import InvalidAPIResponseError
 
 try:
     import unittest.mock as mock
@@ -136,7 +135,7 @@ class MockSolverLoading(unittest.TestCase):
         with requests_mock.mock() as m:
             m.get(solver1_url, text=solver_object(solver_name, True))
             con = dwave_micro_client.Connection(url, token)
-            with self.assertRaises(InvalidAPIResponseError):
+            with self.assertRaises(dwave_micro_client.InvalidAPIResponseError):
                 con.get_solver(solver_name)
 
     def test_load_solver_broken_response(self):

--- a/test/test_mock_solver_loading.py
+++ b/test/test_mock_solver_loading.py
@@ -7,6 +7,7 @@ import unittest
 import requests_mock
 
 import dwave_micro_client
+from dwave_micro_client import InvalidAPIResponseError
 
 try:
     import unittest.mock as mock
@@ -135,7 +136,7 @@ class MockSolverLoading(unittest.TestCase):
         with requests_mock.mock() as m:
             m.get(solver1_url, text=solver_object(solver_name, True))
             con = dwave_micro_client.Connection(url, token)
-            with self.assertRaises(KeyError):
+            with self.assertRaises(InvalidAPIResponseError):
                 con.get_solver(solver_name)
 
     def test_load_solver_broken_response(self):

--- a/test/test_solver.py
+++ b/test/test_solver.py
@@ -2,7 +2,7 @@
 Check the interface to the solver object.
 
 Note:
-    These are all agrigate tests, not really testing single units.
+    These are all aggregate tests, not really testing single units.
 """
 from __future__ import absolute_import, division
 
@@ -21,7 +21,7 @@ except:
 
 
 class PropertyLoading(unittest.TestCase):
-    """Ensure that the propreties of solvers can be retrieved."""
+    """Ensure that the properties of solvers can be retrieved."""
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_load_properties(self):
@@ -109,7 +109,7 @@ class Submission(_QueryTest):
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_submit_full_problem(self):
-        """Submit a problem with all supported coefficents set."""
+        """Submit a problem with all supported coefficients set."""
         # Connect
         con = dwave_micro_client.Connection(config_url, config_token)
         solver = con.get_solver(config_solver)
@@ -141,7 +141,7 @@ class Submission(_QueryTest):
 
     @unittest.skipIf(skip_live, "No live server available.")
     def test_submit_partial_problem(self):
-        """Submit a probem with only some of the terms set."""
+        """Submit a problem with only some of the terms set."""
         # Connect
         con = dwave_micro_client.Connection(config_url, config_token)
         solver = con.get_solver(config_solver)


### PR DESCRIPTION
Use only solvers that support either `ising` or `qubo` problem types.