### PR TITLE
Prepare the first namespaced version for a dev release

### DIFF
--- a/dwave/__init__.py
+++ b/dwave/__init__.py
@@ -1,1 +1,2 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+import pkgutil
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 install_requires = ['requests>=2.18', 'six>=1.10']
 
@@ -7,12 +7,17 @@ extras_require = {
     ':python_version == "2.7"': ['futures']
 }
 
+# Only include packages under the 'dwave' namespace. Do not include tests,
+# benchmarks, etc.
+packages = [package for package in find_packages() if package.startswith('dwave.')]
+
 setup(
-    name='dwave_micro_client',
-    py_modules=['dwave_micro_client'],
-    version='0.2.2',
+    name='dwave-cloud-client',
+    version='0.3.0.dev0',
     description='A minimal client for interacting with SAPI servers.',
     url='https://github.com/dwavesystems/dwave_micro_client',
+    packages=packages,
+    namespace_packages=['dwave'],
     install_requires=install_requires,
     extras_require=extras_require
 )


### PR DESCRIPTION
Change package name to `dwave-cloud-client`.

Use like: `from dwave.cloud.qpu import Client`.